### PR TITLE
設定項目クラスJsonItemの雛形を作成

### DIFF
--- a/src/jsonItem.ts
+++ b/src/jsonItem.ts
@@ -1,0 +1,42 @@
+class JsonItem {
+  key: string[];
+  textData: string;
+  // textData: 設定の該当する部分の文字列データ
+  constructor(textData: string) {
+    this.textData = textData;
+    this.key = this.parseToKey(textData);
+  }
+
+  // keyをパースして読み取るメソッド
+  private parseToKey(textData: string): string[] {
+    // TODO: パース処理
+    return [""];
+  }
+
+  // keyを取得するメソッド
+  public getKey(): string[] {
+    return this.key;
+  }
+
+  // textDataを取得するメソッド
+  public getTextData(): string {
+    return this.textData;
+  }
+}
+
+// itemsをソートする関数
+// キーの辞書順でソートする
+function sortJsonItems(items: JsonItem[]): JsonItem[] {
+  // TODO: itemsをソートする処理
+  return items;
+}
+
+// 第一キーが同じものをグループ化する関数
+// グループ化したものを返す
+function makeItemGroup(items: JsonItem[]): JsonItem[][] {
+  // TODO: itemsをグループ化する処理
+  return [items];
+}
+
+export default JsonItem;
+export { sortJsonItems, makeItemGroup };


### PR DESCRIPTION
設定項目クラス`JsonItem`のメソッドや周辺関数を定義しました．
# 変更点
- **`JsonItem`クラスを作成**
  - 設定項目に対応するjsonの文字列をコンストラクタで受け取って，それをパースしてキーのstring配列とテキストデータで保持するクラスです．
  - キーは次のような感じ．
> 例：キーeditor.formatOnSaveなら["editor", "formatOnSave"]
- **`sortJsonItems()`関数を定義**
  - JsonItemの配列をキーの辞書順でソートする関数です．
  - 実装はしていません．
- **`makeItemGroup()`関数を定義**
  - JsonItemの配列を第一キーが同じものでグルーピングする関数です．
  - 実装はしていません．