### PR TITLE
settings.jsonを操作する関数群の雛形を作成

### DIFF
--- a/src/settingsJson.ts
+++ b/src/settingsJson.ts
@@ -1,0 +1,15 @@
+
+// 設定ファイルを読み込む処理を記述する
+// ユーザースペースの設定ファイルと，ワークスペースの設定ファイルで分岐する必要あり．
+function readSetting(): string {
+  // TODO: 設定ファイルを読み込む処理
+  return "";
+}
+
+// 設定ファイルを書き込む処理を記述する
+// ユーザースペースの設定ファイルと，ワークスペースの設定ファイルで分岐する必要あり．
+function writeSetting(textData: string): void {
+  // TODO: 設定ファイルを書き込む処理
+}
+
+export { readSetting, writeSetting };


### PR DESCRIPTION
settings.jsonの操作はここに定義された関数で行います．
# 変更点
- **`readSetting()`を定義**
  - 設定ファイルを読み込む関数です．
  - ユーザースペースの設定ファイルなのか，ワークスペースの設定ファイルを読み込むのかによって条件分岐をする必要があると思います．
  - 実装はしていません．
- **`writeSetting()`を定義**
  - 設定ファイルに書き込む関数です．
  - 実装はしていません．