### PR TITLE
writeSetting関数の実装

### DIFF
--- a/src/settingsJson.ts
+++ b/src/settingsJson.ts
@@ -12,8 +12,9 @@ async function readSetting(): Promise<string> {
 }
 
 // 設定ファイルを書き込む処理を記述する
-function writeSetting(textData: string): void {
-  // TODO: 設定ファイルを書き込む処理
+async function writeSetting(textData: string): Promise<void> {
+  await vscode.env.clipboard.writeText(textData);
+  await vscode.window.showInformationMessage("Copied to clipboard");
 }
 
 export { readSetting, writeSetting };


### PR DESCRIPTION
writeSetting関数を実装しました．

ユーザーのクリップボードに引数で渡したstringを書き込みます．