### PR TITLE
up: jsonItem.ts パース処理のメソッド,ソートとグループ化の関数の作成

### DIFF
--- a/src/jsonItem.ts
+++ b/src/jsonItem.ts
@@ -8,9 +8,8 @@ class JsonItem {
   }
 
   // keyをパースして読み取るメソッド
-  public parseToKey(textData: string): string[] {
-    // private parseToKey(textData: string): string[] {
-    // TODO: パース処理
+  private parseToKey(textData: string): string[] {
+    // パース処理
     let textDataline = textData.split("\n");
     const c = textDataline.length;
     
@@ -22,11 +21,11 @@ class JsonItem {
         continue;
       }
       if (line.match(re)) {
-        let key_str = line.match(re);
-        if (key_str) {
-          const key_str2 = key_str[0].slice(1, key_str[0].length - 2);
-          const key_str_split = key_str2.split(".");
-          return key_str_split;
+        let keyStr = line.match(re);
+        if (keyStr) {
+          const keyStr2 = keyStr[0].slice(1, keyStr[0].length - 2);
+          const keyStrSplit = keyStr2.split(".");
+          return keyStrSplit;
         }
       }
     }
@@ -49,14 +48,14 @@ class JsonItem {
 // itemsをソートする関数
 // キーの辞書順でソートする
 function sortJsonItems(items: JsonItem[]): JsonItem[] {
-  // TODO: itemsをソートする処理
+  // itemsをソートする処理
   return items.sort((a, b) => (a.getKey() > b.getKey() ? 1 : -1));
 }
 
 // 第一キーが同じものをグループ化する関数
 // グループ化したものを返す
 function makeItemGroup(items: JsonItem[]): JsonItem[][] {
-  // TODO: itemsをグループ化する処理
+  // itemsをグループ化する処理
   let c = 0;
   let keyname = items[0];
   const groups = [];

--- a/src/jsonItem.ts
+++ b/src/jsonItem.ts
@@ -8,8 +8,30 @@ class JsonItem {
   }
 
   // keyをパースして読み取るメソッド
-  private parseToKey(textData: string): string[] {
+  public parseToKey(textData: string): string[] {
+    // private parseToKey(textData: string): string[] {
     // TODO: パース処理
+    let textDataline = textData.split("\n");
+    const c = textDataline.length;
+    
+    for (let i = 0; i < c; i++) {
+      let line = textDataline[i];
+      const re = /".*":/gi;
+      const re2 = /\/\//gi;
+      if (line.match(re2)) {
+        continue;
+      }
+      if (line.match(re)) {
+        let key_str = line.match(re);
+        if (key_str) {
+          const key_str2 = key_str[0].slice(1, key_str[0].length - 2);
+          const key_str_split = key_str2.split(".");
+          return key_str_split;
+        }
+      }
+    }
+
+
     return [""];
   }
 
@@ -28,14 +50,26 @@ class JsonItem {
 // キーの辞書順でソートする
 function sortJsonItems(items: JsonItem[]): JsonItem[] {
   // TODO: itemsをソートする処理
-  return items;
+  return items.sort((a, b) => (a.getKey() > b.getKey() ? 1 : -1));
 }
 
 // 第一キーが同じものをグループ化する関数
 // グループ化したものを返す
 function makeItemGroup(items: JsonItem[]): JsonItem[][] {
   // TODO: itemsをグループ化する処理
-  return [items];
+  let c = 0;
+  let keyname = items[0];
+  const groups = [];
+  for (let i = 0; i < items.length; i++) {
+    if (items[i] !== keyname) {
+      groups.push(items.slice(c, i));
+    }
+    c = i;
+    keyname = items[i];
+  }
+  groups.push(items.slice(c, items.length));
+
+  return groups;
 }
 
 export default JsonItem;


### PR DESCRIPTION
# 変更点
## parseToKey: keyをパースして読み取るメソッドの作成
'textData'を行ごとに分割し，空行とコメント行を除いた行からキーを抽出し，'.'で分割したものを返す．

## sortJsonItems: キーを辞書順にソートする関数の作成
sort関数でキーをソート．

## makeItemGroup: 第一キーが同じものをグループ化する関数の作成
'sortJsonItems'でソートしたものを第一キーが同じものでグループ化し，2次元配列化する．
